### PR TITLE
fix fifty_percent generator for odd sizes

### DIFF
--- a/freebsd.c
+++ b/freebsd.c
@@ -31,8 +31,8 @@
 #if defined(LIBC_SCCS) && !defined(lint)
 static char sccsid[] = "@(#)qsort.c	8.1 (Berkeley) 6/4/93";
 #endif /* LIBC_SCCS and not lint */
-#include <sys/cdefs.h>
-/*__FBSDID("$FreeBSD$");*/
+/*#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");*/
 
 #include <stdlib.h>
 

--- a/qsort.c
+++ b/qsort.c
@@ -95,6 +95,7 @@ void fifty_percent(uint32_t *array, size_t nums) {
   pcg32_random_t r;
   memcpy(&r, &start, sizeof(pcg32_random_t));
   for (size_t i = 0; i < nums/2; i++) array[2*i] = i, array[2*i+1] = pcg32_random_r(&r);
+  if (nums % 2) array[nums - 1] = nums / 2;
 }
 
 void triangle(uint32_t *array, size_t nums) {


### PR DESCRIPTION
If 'nums' is odd, the loop does not cover the last array element. Assign to it explicitly if that's the case.

I also wonder, what the following ("triangle") generator was supposed to produce?